### PR TITLE
fix: mark Emotion components as client

### DIFF
--- a/frontend/src/app/LayoutShell.tsx
+++ b/frontend/src/app/LayoutShell.tsx
@@ -1,0 +1,56 @@
+"use client";
+
+import styled from "@emotion/styled";
+
+const LayoutWrapper = styled.div`
+    display: flex;
+    flex-direction: column;
+    min-height: 100vh;
+`;
+
+const NavHeader = styled.header`
+    background: ${({ theme }) => theme.colors.accent};
+    color: #fff;
+    padding: 28px 16px 24px 16px;
+    text-align: center;
+    font-size: 2rem;
+    font-weight: bold;
+    letter-spacing: 0.05em;
+`;
+
+const Content = styled.main`
+    flex: 1;
+    width: 100%;
+    max-width: 1200px;
+    margin: 0 auto;
+    padding: 32px 16px;
+`;
+
+const Footer = styled.footer`
+    background: ${({ theme }) => theme.colors.dark};
+    color: ${({ theme }) => theme.colors.light};
+    text-align: center;
+    font-size: 1rem;
+    padding: 16px 0 18px 0;
+    letter-spacing: 0.04em;
+`;
+
+export default function LayoutShell({
+    children,
+}: {
+    children: React.ReactNode;
+}) {
+    return (
+        <LayoutWrapper>
+            <NavHeader>
+                <span role="img" aria-label="plant" style={{ fontSize: 32, marginRight: 8 }}>
+                    🌱
+                </span>
+                Plant Store Demo
+            </NavHeader>
+            <Content>{children}</Content>
+            <Footer>Dev environment</Footer>
+        </LayoutWrapper>
+    );
+}
+

--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -1,89 +1,25 @@
-"use client";
-
 import type { Metadata } from "next";
 import Providers from "./providers/Providers";
-import styled from "@emotion/styled";
-import { ThemeProvider, Theme } from "@emotion/react";
-
-declare module "@emotion/react" {
-        export interface Theme {
-                colors: {
-                        accent: string;
-                        dark: string;
-                        light: string;
-                };
-        }
-}
-
-const theme: Theme = {
-        colors: {
-                accent: "#ff6347",
-                dark: "#333",
-                light: "#f4f4f4",
-        },
-};
+import LayoutShell from "./LayoutShell";
 
 export const metadata: Metadata = {
-        title: "Plant Store Starter",
-        description: "Demo application showcasing plants with Next.js and Django",
+    title: "Plant Store Starter",
+    description: "Demo application showcasing plants with Next.js and Django",
 };
 
-const LayoutWrapper = styled.div`
-        display: flex;
-        flex-direction: column;
-        min-height: 100vh;
-`;
-
-const NavHeader = styled.header`
-        background: ${({ theme }) => theme.colors.accent};
-        color: #fff;
-        padding: 28px 16px 24px 16px;
-        text-align: center;
-        font-size: 2rem;
-        font-weight: bold;
-        letter-spacing: 0.05em;
-`;
-
-const Content = styled.main`
-        flex: 1;
-        width: 100%;
-        max-width: 1200px;
-        margin: 0 auto;
-        padding: 32px 16px;
-`;
-
-const Footer = styled.footer`
-        background: ${({ theme }) => theme.colors.dark};
-        color: ${({ theme }) => theme.colors.light};
-        text-align: center;
-        font-size: 1rem;
-        padding: 16px 0 18px 0;
-        letter-spacing: 0.04em;
-`;
-
 export default function RootLayout({
-        children,
+    children,
 }: {
-        children: React.ReactNode;
+    children: React.ReactNode;
 }) {
-        return (
-                <ThemeProvider theme={theme}>
-                        <html lang="en">
-                                <body>
-                                        <Providers>
-                                                <LayoutWrapper>
-                                                        <NavHeader>
-                                                                <span role="img" aria-label="plant" style={{ fontSize: 32, marginRight: 8 }}>
-                                                                        🌱
-                                                                </span>
-                                                                Plant Store Demo
-                                                        </NavHeader>
-                                                        <Content>{children}</Content>
-                                                        <Footer>Dev environment</Footer>
-                                                </LayoutWrapper>
-                                        </Providers>
-                                </body>
-                        </html>
-                </ThemeProvider>
-        );
+    return (
+        <html lang="en">
+            <body>
+                <Providers>
+                    <LayoutShell>{children}</LayoutShell>
+                </Providers>
+            </body>
+        </html>
+    );
 }
+

--- a/frontend/src/app/providers/Providers.tsx
+++ b/frontend/src/app/providers/Providers.tsx
@@ -2,9 +2,9 @@
 
 import { useState } from "react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { ThemeProvider, Global, css } from "@emotion/react";
+import { ThemeProvider, Global, css, Theme } from "@emotion/react";
 
-const theme = {
+const theme: Theme = {
     colors: {
         dark: "#1B5E20",
         medium: "#81C784",

--- a/frontend/src/components/Loading.tsx
+++ b/frontend/src/components/Loading.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import styled from "@emotion/styled";
 
 const LoaderContainer = styled.div`

--- a/frontend/src/components/Tooltip.tsx
+++ b/frontend/src/components/Tooltip.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import { ReactNode } from "react";
 import styled from "@emotion/styled";
 

--- a/frontend/src/components/ui.tsx
+++ b/frontend/src/components/ui.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import styled from "@emotion/styled";
 import Link from "next/link";
 

--- a/frontend/src/types/emotion.d.ts
+++ b/frontend/src/types/emotion.d.ts
@@ -1,0 +1,13 @@
+import "@emotion/react";
+
+declare module "@emotion/react" {
+    export interface Theme {
+        colors: {
+            accent: string;
+            dark: string;
+            light: string;
+            medium: string;
+        };
+    }
+}
+


### PR DESCRIPTION
## Summary
- mark Emotion-styled components as client to avoid `createContext` errors
- refactor root layout to separate server metadata from client shell
- type Emotion theme for consistent color access

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: prompts for ESLint config)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a0bd842164832aa80667cca99406e6